### PR TITLE
Fix null exception when trying to deregister forcibly unspawned Grinders or Hoppers

### DIFF
--- a/Source/VNPE/Buildings/Building_NutrientGrinder.cs
+++ b/Source/VNPE/Buildings/Building_NutrientGrinder.cs
@@ -100,8 +100,15 @@ namespace VNPE
 
         public void UnregisterHopper(Thing hopper)
         {
-            if (cachedHoppers.Contains(hopper))
-                cachedHoppers.Remove(hopper);
+            if (cachedHoppers != null)
+            {
+                // Remove null or destroyed hoppers first
+                cachedHoppers.RemoveAll(h => h == null || h.Destroyed);
+                if (hopper != null && cachedHoppers.Contains(hopper))
+                {
+                    cachedHoppers.Remove(hopper);
+                }
+            }
         }
 
         private Thing FindFeedInAnyHopper()

--- a/Source/VNPE/Comps/CompRegisterToGrinder.cs
+++ b/Source/VNPE/Comps/CompRegisterToGrinder.cs
@@ -9,10 +9,21 @@ namespace VNPE
 
         public override void PostDeSpawn(Map map, DestroyMode mode = DestroyMode.Vanish)
         {
-            base.PostDeSpawn(map,mode);
-            for (int i = 0; i < grinders.Count; i++)
+            base.PostDeSpawn(map, mode);
+
+            if (grinders != null)
             {
-                grinders[i].UnregisterHopper(parent);
+                // Remove null or destroyed grinders first
+                grinders.RemoveAll(g => g == null || g.Destroyed);
+
+                foreach (var grinder in grinders)
+                {
+                    if (grinder != null && !grinder.Destroyed)
+                    {
+                        // Defensive: Remove this hopper from the grinder, checking for nulls inside grinder implementation
+                        grinder.UnregisterHopper(parent);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
When a Gravship launches with a nutrient network aboard, there is the possibility that the list of hoppers or grinders will point to now-null objects, as they have been forcibly removed by the launch. This fix checks if there are null refs, and removes them, prior to trying to unregister the hoppers from the grinders.

Attempt to navigate Github, #5. This should ONLY include the files meant to be modified in the merge. Ignore prior PRs. I don't know Github, and coding is not my career path. Nonetheless, I hope this helps.